### PR TITLE
Fix ajax notification call

### DIFF
--- a/x2engine/protected/controllers/NotificationsController.php
+++ b/x2engine/protected/controllers/NotificationsController.php
@@ -41,6 +41,7 @@
  */
 Yii::import('application.models.Relationships');
 Yii::import('application.models.Tags');
+Yii::import('application.components.X2Html');
 
 class NotificationsController extends CController {
 


### PR DESCRIPTION
Was getting a Fatal error class "X2Html" not found when getting notifications. This patch fixed it. Not sure if it's the right spot for it.