### PR TITLE
session.save_path error on install

### DIFF
--- a/x2engine/iii.php
+++ b/x2engine/iii.php
@@ -1,0 +1,2 @@
+<?php
+phpinfo();

--- a/x2engine/iii.php
+++ b/x2engine/iii.php
@@ -1,2 +1,0 @@
-<?php
-phpinfo();

--- a/x2engine/protected/components/views/requirements.php
+++ b/x2engine/protected/components/views/requirements.php
@@ -451,6 +451,13 @@ if(!($requirements['extensions']['hash']=extension_loaded('hash'))){
 
 // Check the session save path:
 $ssp = ini_get('session.save_path');
+
+// session.save_path has an optional parameter to set the nest level. obviously we need to remove this and get the actual path
+if (strstr($ssp,';')) {
+	$tmp=explode(';',$ssp);
+	if (count($tmp)>1) $ssp = $tmp[1];
+}
+
 if(!is_writable($ssp)){
 	$reqMessages[3][] = strtr(installer_t('The path defined in session.save_path ({ssp}) is not writable.'), array('{ssp}' => $ssp));
 }


### PR DESCRIPTION
According to the documentation, 

The path can be defined as:
session.save_path = "N;/path"
where N is an integer.  Instead of storing all the session files in /path, what this will do is use subdirectories N-levels deep, and store the session data in those directories.  This is useful if your OS has problems with many files in one directory, and is a more efficient layout for servers that handle many sessions.

Existing software will check '3;/sessions' (for example), which is an invalid path. The software should first remove the nest parameter if it exists, then check the sessions path.
