### PR TITLE
Fixed date format issue under French locale

### DIFF
--- a/x2engine/js/publisher/PublisherTab.js
+++ b/x2engine/js/publisher/PublisherTab.js
@@ -110,6 +110,10 @@ PublisherTab.prototype._setUpAjaxSuccessHandler = function () {
     that._form$ = that._element.find ('form');
 
     x2.X2Form.getInstance (that._form$).onAjaxSuccess = function (data) {
+        var persistData = ['dateformat', 'timeformat', 'ampmformat', 'region', 'monthNamesShort'];
+        var dataVals = {};
+        // Save default locale settings to replace after resetting form
+        $.each(persistData, function(i, v) { dataVals[v] = that._form$.data(v); });
         that._form$.replaceWith (data.page);
         that._setUpAjaxSuccessHandler ();
         if (!$(that._elemSelector).find ('.error').length) {
@@ -120,6 +124,7 @@ PublisherTab.prototype._setUpAjaxSuccessHandler = function () {
                 $(that._elemSelector).closest ('.ui-dialog').remove ();
             }
         }
+        $.each(dataVals, function(i, v) { that._form$.data(i, v); });
     };
 };
 

--- a/x2engine/protected/components/ActiveDateRangeInput.php
+++ b/x2engine/protected/components/ActiveDateRangeInput.php
@@ -84,6 +84,17 @@ class ActiveDateRangeInput extends X2Widget {
         return $this->_JSClassParams;
     }
 
+    public function getDatePickerOptions() {
+        $datePickerOptions = array (
+            'dateFormat' => Formatter::formatDatePicker ('medium'),
+            'timeFormat' => Formatter::formatTimePicker (),
+            'ampm' => Formatter::formatAMPM (),
+        );
+        if (Yii::app()->getLanguage() === 'fr')
+            $datePickerOptions['monthNamesShort'] = Formatter::getPlainAbbrMonthNames();
+        return $datePickerOptions;
+    }
+
     public function run () {
         $this->registerPackages ();
         $this->instantiateJSClass ();

--- a/x2engine/protected/components/publisher/PublisherEventTab.php
+++ b/x2engine/protected/components/publisher/PublisherEventTab.php
@@ -81,16 +81,21 @@ class PublisherEventTab extends PublisherTimeTab {
         $timeformat = Formatter::formatTimePicker();
         $ampmformat = Formatter::formatAMPM();
         $region = Yii::app()->locale->getLanguageId(Yii::app()->locale->getId());
+        $monthNamesShort = '""';
         if($region == 'en')
             $region = '';
+        else if ($region == 'fr')
+            $monthNamesShort = CJSON::encode(Formatter::getPlainAbbrMonthNames());
 
         // save default values of fields for when the publisher is submitted and then reset
         Yii::app()->clientScript->registerScript('defaultValues', '
             // set date and time format for when datetimepicker is recreated
-            $("#publisher-form").data("dateformat", "'.$dateformat.'");
-            $("#publisher-form").data("timeformat", "'.$timeformat.'");
-            $("#publisher-form").data("ampmformat", "'.$ampmformat.'");
-            $("#publisher-form").data("region", "'.$region.'");
+            var form$ = x2.publisher.getForm ();
+            form$.data("dateformat", "'.$dateformat.'");
+            form$.data("timeformat", "'.$timeformat.'");
+            form$.data("ampmformat", "'.$ampmformat.'");
+            form$.data("region", "'.$region.'");
+            form$.data("monthNamesShort", '.$monthNamesShort.');
         ', CClientScript::POS_READY);
 
         parent::renderTab ($viewParams);

--- a/x2engine/protected/components/views/activeDateRangeInput.php
+++ b/x2engine/protected/components/views/activeDateRangeInput.php
@@ -85,11 +85,7 @@ Yii::app()->clientScript->registerCss('activeDateRangeInput',"
                 'onClick' => "$('#ui-datepicker-div').css('z-index', '100');", 
                 'class' => 'action-due-date',
                 'id' => $this->resolveId ('action-due-date'),
-            ), 'datetime', array_merge (array (
-                'dateFormat' => Formatter::formatDatePicker ('medium'),
-                'timeFormat' => Formatter::formatTimePicker (),
-                'ampm' => Formatter::formatAMPM (),
-            ), $this->options));
+            ), 'datetime', array_merge ($this->datePickerOptions, $this->options));
 
         echo CHtml::activeLabel(
             $this->model, $this->endDateAttribute, 
@@ -99,11 +95,7 @@ Yii::app()->clientScript->registerCss('activeDateRangeInput',"
                 'onClick' => "$('#ui-datepicker-div').css('z-index', '100');", 
                 'class' => 'action-complete-date',
                 'id' => $this->resolveId ('action-complete-date'),
-            ), 'datetime', array_merge (array (
-                'dateFormat' => Formatter::formatDatePicker ('medium'),
-                'timeFormat' => Formatter::formatTimePicker (),
-                'ampm' => Formatter::formatAMPM (),
-            ), $this->options));
+            ), 'datetime', array_merge ($this->datePickerOptions, $this->options));
         ?>
     </div>
 </div>

--- a/x2engine/protected/modules/calendar/assets/js/calendar.js
+++ b/x2engine/protected/modules/calendar/assets/js/calendar.js
@@ -96,7 +96,8 @@ CalendarManager.prototype.insertDate = function(date, view, publisherName){
     var dateformat = form$.data('dateformat');
     var timeformat = form$.data('timeformat');
     var ampmformat = form$.data('ampmformat');
-    var region = x2.publisher.getForm ().data('region');
+    var region = form$.data('region');
+    var monthNamesShort = form$.data('monthNamesShort');
 
     if(typeof(dateformat) == 'undefined') {
         dateformat = 'M d, yy';
@@ -110,6 +111,9 @@ CalendarManager.prototype.insertDate = function(date, view, publisherName){
     if(typeof(region) == 'undefined') {
         region = '';
     }
+    if(typeof(monthNamesShort) == 'undefined') {
+        monthNamesShort = '';
+    }
 
 
     form$.find ('.action-due-date').datetimepicker("destroy");
@@ -122,6 +126,7 @@ CalendarManager.prototype.insertDate = function(date, view, publisherName){
                 'dateFormat':dateformat,
                 'timeFormat':timeformat,
                 'ampm':ampmformat,
+                'monthNamesShort':monthNamesShort,
                 'changeMonth':true,
                 'changeYear':true, 
                 'defaultDate': newDate.begin
@@ -140,6 +145,7 @@ CalendarManager.prototype.insertDate = function(date, view, publisherName){
                 'dateFormat':dateformat,
                 'timeFormat':timeformat,
                 'ampm':ampmformat,
+                'monthNamesShort':monthNamesShort,
                 'changeMonth':true,
                 'changeYear':true,
                 'defaultDate': newDate.end


### PR DESCRIPTION
* Updated datepicker options to include short month names under French
  locale. Previously, the short months used by the datepicker contained
  a trailing period, e.g., 'dec.', resulting in the date failing to
  parse, and thus the event would not appear on the calendar
* Updated form onAjaxSuccess for PublisherTab to save default locale
  settings from data and reattach to the new form. Without doing so, the
  form would be reinstantiated with datepickers using default en locale.