### PR TITLE
Improvements to header format handling in EmailDeliveryBehavior::addr…

### DIFF
--- a/x2engine/protected/components/behaviors/EmailDeliveryBehavior.php
+++ b/x2engine/protected/components/behaviors/EmailDeliveryBehavior.php
@@ -115,10 +115,16 @@ class EmailDeliveryBehavior extends CBehavior {
         $tokenizedHeader = str_replace(',',$delimiter,strtr($header,$tokens));
         $headerPieces = explode($delimiter,strtr($tokenizedHeader,$values));
         $headerArray = array();
-        foreach($headerPieces as $recipient){
+        $skipNext = false;
+        foreach($headerPieces as $i => $recipient){
             $recipient = trim($recipient);
             if(empty($recipient))
                 continue;
+            if ($skipNext) {
+                // if this piece was used to reconstruct on the last iteration
+                $skipNext = false;
+                continue;
+            }
             $matches = array();
             $emailValidator = new CEmailValidator;
 
@@ -132,12 +138,23 @@ class EmailDeliveryBehavior extends CBehavior {
 
                 // (with or without quotes)
                 if(count($matches) == 3 && $emailValidator->validateValue($matches[2])){  
-                    $headerArray[] = array($matches[1], $matches[2]);
+                    $headerArray[] = array(trim($matches[1], "' "), $matches[2]);
                 }else{
                     if (!$ignoreInvalidAddresses)
                         throw new CException(Yii::t('app', 'Invalid email address list.'));
                 }
             }else{
+                if ($i < count($headerPieces) - 1) {
+                    // Maybe quotes were left off? Check if the next piece is part of this address
+                    $testRecipient = trim($recipient) . ',' . $headerPieces[$i+1];
+                    if (preg_match('/^"?((?:\\\\"|[^"])*[^\s])"?\s*<(.+)>$/i', $testRecipient, $matches)){
+                        if(count($matches) == 3 && $emailValidator->validateValue($matches[2])) {
+                            $headerArray[] = array(trim($matches[1], "' "), $matches[2]);
+                            $skipNext = true;
+                            continue;
+                        }
+                    }
+                }
                 if (!$ignoreInvalidAddresses)
                     throw new CException(Yii::t('app', 'Invalid email address list:'.$recipient));
             }

--- a/x2engine/protected/tests/unit/components/EmailDeliveryBehaviorTest.php
+++ b/x2engine/protected/tests/unit/components/EmailDeliveryBehaviorTest.php
@@ -48,13 +48,32 @@ class EmailDeliveryBehaviorTest extends X2TestCase {
      */
     public function testAddressHeaderToArray() {
         $addressHeader = '"Butts, Seymour" <seymour@butts.com>, "I.P. Freely"<ip@free.ly>, johnsmith@gmail.com, <only@email.com>';
-        $addressHeaderArray = EmailDeliveryBehavior::addressHeaderToArray($addressHeader);
-        $this->assertEquals(array(
+        $addressArray = array(
             array('Butts, Seymour','seymour@butts.com'),
             array('I.P. Freely','ip@free.ly'),
             array('','johnsmith@gmail.com'),
-            array('','only@email.com')
-        ),$addressHeaderArray);
+            array('','only@email.com'),
+        );
+        $addressHeaderArray = EmailDeliveryBehavior::addressHeaderToArray($addressHeader);
+        $this->assertEquals($addressArray,$addressHeaderArray);
+
+        // Test adjustments to handle a few other unexpected formats
+        $unexpectedAddressHeader = 'Quotes-Test, No <noquotes@email.com>, "\'Twice, Quoted\'" <twice@email.com>, \'Quoted, Single\' <single@email.com>, No Quotes <noquotes@email.com>, \'Single Quoted\' <single@email.com>, "\'Twice Quoted\'" <twice@email.com>';
+        $unexpectedAddressArray = array(
+            array('Quotes-Test, No','noquotes@email.com'),
+            array("Twice, Quoted", 'twice@email.com'),
+            array('Quoted, Single','single@email.com'),
+            array('No Quotes','noquotes@email.com'),
+            array('Single Quoted','single@email.com'),
+            array("Twice Quoted", 'twice@email.com'),
+        );
+        $addressHeaderArray = EmailDeliveryBehavior::addressHeaderToArray($unexpectedAddressHeader);
+        $this->assertEquals($unexpectedAddressArray,$addressHeaderArray);
+
+        // Test compatibility with a header composed of combined formats
+        $combined = $unexpectedAddressHeader . ', ' . $addressHeader;
+        $addressHeaderArray = EmailDeliveryBehavior::addressHeaderToArray($combined);
+        $this->assertEquals(array_merge($unexpectedAddressArray, $addressArray),$addressHeaderArray);
     }
 
 }


### PR DESCRIPTION
…essHeaderToArray

To improve compatibility with email address header formats, additional
checks have been added to addressHeaderToArray when initial validation
fails. This will use the next piece of the $headerArray to see if we've
inadvertantly split in an incorrect position, due to use of single quotes,
or embedded single quotes, e.g. "'Test Contact'".