### PR TITLE
Added warning and handling when removing a field used in list criteria

### DIFF
--- a/x2engine/protected/controllers/AdminController.php
+++ b/x2engine/protected/controllers/AdminController.php
@@ -2930,6 +2930,9 @@ class AdminController extends X2Controller {
         if (isset($_POST['field']) && $_POST['field'] != "") {
             $id = $_POST['field'];
             $field = Fields::model()->findByPk($id);
+            $listsUsingField = false;
+            if ($field->modelName === 'Contacts')
+                $listsUsingField = $field->checkListCriteria();
             if ($getCount) {
                 $nonNull = $field->countNonNull();
                 if ($nonNull) {
@@ -2940,7 +2943,24 @@ class AdminController extends X2Controller {
                 } else {
                     echo Yii::t('admin', 'The field appears to be empty. Deleting it will not result in any data loss.');
                 }
+                if ($listsUsingField) {
+                    echo '<br /><br />';
+                    echo Yii::t('admin', 'This field is used as criteria for the following '.
+                        'lists. You can remove them manually, or proceed to remove these '.
+                        'criteria automatically. Note: This may change the contents of your list.');
+                    echo '<ul>';
+                    foreach ($listsUsingField as $list) {
+                        echo '<li>'.$list.'</li>';
+                    }
+                    echo '</ul>';
+                }
                 Yii::app()->end();
+            }
+            if ($listsUsingField) {
+                foreach ($listsUsingField as $id => $link) {
+                    Yii::app()->db->createCommand()
+                        ->delete('x2_list_criteria', 'id = :id', array(':id' => $id));
+                }
             }
             $field->delete();
         }

--- a/x2engine/protected/models/Fields.php
+++ b/x2engine/protected/models/Fields.php
@@ -195,6 +195,26 @@ class Fields extends CActiveRecord {
             )->queryScalar();
     }
 
+    /**
+     * Check for use of this field in dynamic list criteria
+     * @return array Links to lists using this field in criteria
+     */
+    public function checkListCriteria() {
+        $lists = Yii::app()->db->createCommand()
+            ->select('l.id, l.name, c.id as criteriaId')
+            ->from('x2_list_criteria c')
+            ->join('x2_lists l', 'l.id = c.listId')
+            ->where('c.attribute = :attr', array(':attr' => $this->fieldName))
+            ->queryAll();
+        if (!empty($lists)) {
+            $listNames = array();
+            foreach ($lists as $list) {
+                $listNames[$list['criteriaId']] = CHtml::link($list['name'], array('/contacts/contacts/list?id='.$list['id']));
+            }
+            return $listNames;
+        }
+    }
+
     public static function getLinkTypes () {
         return Yii::app()->db->createCommand ("
             SELECT distinct(modelName)

--- a/x2engine/protected/tests/unit/models/FieldsTest.php
+++ b/x2engine/protected/tests/unit/models/FieldsTest.php
@@ -68,6 +68,22 @@ class FieldsTest extends X2TestCase {
         $this->assertEquals(2,(int) $f->countNonNull());
     }
 
+    public function testCheckListCriteria() {
+        $f = new Fields;
+        $f->modelName = 'Contacts';
+        $f->fieldName = 'email';
+        Yii::app()->fixture->load(array('listCriteria' => 'X2ListCriterion'));
+        Yii::app()->fixture->load(array('lists' => 'X2List'));
+        $lists = $f->checkListCriteria();
+        $this->assertEquals(1, count($lists));
+        reset($lists);
+        $criteriaId = key($lists);
+        $this->assertEquals(38, $criteriaId);
+        $matched = preg_match('/href="[^?]+\?id=(\d+)"/', $lists[$criteriaId], $matches);
+        $this->assertEquals(1, $matched);
+        $this->assertEquals(22, $matches[1]);
+    }
+
     public function setup () {
         $this->_testColumnName = null;
         $this->_testTableName = null;


### PR DESCRIPTION
Previously, if a field used in dynamic list criteria was removed,
various locations in the app would error due to access of the missing
field. A warning is now presented when removing the field, and if
ignored, the criteria will be removed.

* Added checkListCriteria() helper method to Fields
* Updated action called via ajax to render a warning when checking for
  data loss, and to clean up list criteria still using that field
* Added unit test for checkListCriteria()