### PR TITLE
Added option to disable fingerprint dupe handling on a per-form basis

### DIFF
--- a/x2engine/js/WebFormDesigner/WebFormDesigner.js
+++ b/x2engine/js/WebFormDesigner/WebFormDesigner.js
@@ -584,6 +584,13 @@ x2.WebFormDesigner = (function() {
         } else {
             $('#thankYouText').val ('');
         }
+        if (typeof form.fingerprintDetection !== 'undefined') {
+            if (parseInt (form.fingerprintDetection, 10) === 1) {
+                $('#fingerprint-detection-checkbox').prop ('checked', true);
+            } else {
+                $('#fingerprint-detection-checkbox').prop ('checked', false);
+            }
+        }
 
         this._updateExtraFields (form);
         this._updateCustomFields (form);

--- a/x2engine/protected/components/CreateWebFormAction.php
+++ b/x2engine/protected/components/CreateWebFormAction.php
@@ -114,6 +114,11 @@ class CreateWebFormAction extends CAction {
             } else {
                 $model->requireCaptcha = 0;
             }
+            if(isset($_POST['fingerprintDetection'])) {
+                $model->fingerprintDetection = 1;
+            } else {
+                $model->fingerprintDetection = 0;
+            }
             if(isset($_POST['redirectUrl'])) {
                 $model->redirectUrl = $_POST['redirectUrl'];
             }

--- a/x2engine/protected/components/WebFormAction.php
+++ b/x2engine/protected/components/WebFormAction.php
@@ -125,7 +125,8 @@ class WebFormAction extends CAction {
                     $oldest = $duplicates[0];
                 }
 
-                if (Yii::app()->settings->enableFingerprinting && isset ($_POST['fingerprint'])) {
+                if (Yii::app()->settings->enableFingerprinting && isset ($_POST['fingerprint']) &&
+                        isset($extractedParams['fingerprintDetection']) && $extractedParams['fingerprintDetection']) {
                     $attributes = (isset($_POST['fingerprintAttributes']))?
                         json_decode($_POST['fingerprintAttributes'], true) : array();
 
@@ -731,6 +732,7 @@ class WebFormAction extends CAction {
                 $extractedParams['header'] = '';
                 $extractedParams['userEmailTemplate'] = null;
                 $extractedParams['webleadEmailTemplate'] = null;
+                $extractedParams['fingerprintDetection'] = true;
 
                 if (isset ($webForm)) { // new method
                     if (!empty ($webForm->header)) 
@@ -739,6 +741,8 @@ class WebFormAction extends CAction {
                         $extractedParams['userEmailTemplate'] = $webForm->userEmailTemplate;
                     if (!empty ($webForm->webleadEmailTemplate)) 
                         $extractedParams['webleadEmailTemplate'] = $webForm->webleadEmailTemplate;
+                    if (empty ($webForm->fingerprintDetection))
+                        $extractedParams['fingerprintDetection'] = $webForm->fingerprintDetection;
                 } else { // legacy method
                     if(isset($_GET['header'])){ 
                         $webFormLegacy = WebForm::model()->findByPk($_GET['header']);

--- a/x2engine/protected/components/WebFormDesigner/views/weblead.php
+++ b/x2engine/protected/components/WebFormDesigner/views/weblead.php
@@ -162,4 +162,22 @@ if($this->edition == 'pro'):
     ))
     ?>
 </div>
+<div class="row webform-tab-content" id="fingerprint-detection-input-container" data-tab='advanced-tab'>
+    <h4>
+        <?php echo Yii::t('marketing','X2Identity duplicate detection') .':'; ?>
+    </h4>
+    <p class="fieldhelp" style="width: 100%">
+        <?php echo Yii::t('marketing','Configure whether duplicate detection will be performed '.
+            'using the lead\'s fingerprint. This setting should be disabled for any form used '.
+            'from a single device to capture leads.'); ?>
+    </p>
+    <div class="row">
+        <label class='left-label' for='fingerprintDetection'>
+            <?php echo Yii::t('app', 'Enable duplicate detection by fingerprint: '); ?>
+        </label>
+        <input id='fingerprint-detection-checkbox' type='checkbox'  name='fingerprintDetection'>
+    </div>
+
+    <br/>
+</div>
 <?php endif;  ?>

--- a/x2engine/protected/modules/marketing/data/install.sql
+++ b/x2engine/protected/modules/marketing/data/install.sql
@@ -64,6 +64,7 @@ CREATE TABLE x2_web_forms(
     generateLead         TINYINT DEFAULT 0,
     generateAccount      TINYINT DEFAULT 0,
     requireCaptcha       TINYINT DEFAULT 0,
+    fingerprintDetection TINYINT DEFAULT 1,
     thankYouText         TEXT DEFAULT NULL,
     PRIMARY KEY (id)
 ) COLLATE = utf8_general_ci;


### PR DESCRIPTION
In the case that the form was used from a single device for collecting
leads, the fingerprint detection would retrieve the previous Contact.
This resulted in the original record being updated with the subsequent
submission, instead of creating the new web lead.