### PR TITLE
Misc performance improvements for Campaign mailing

### DIFF
--- a/x2engine/protected/modules/actions/models/Actions.php
+++ b/x2engine/protected/modules/actions/models/Actions.php
@@ -308,6 +308,10 @@ class Actions extends X2Model {
         return $success;
     }
 
+    public function getMetaDataFieldNames() {
+        return array_keys($this->metaDataTemp);
+    }
+
     /**
      * Retrieve a list of model links, indexed by model name
      * @return array

--- a/x2engine/protected/modules/contacts/views/contacts/listIndex.php
+++ b/x2engine/protected/modules/contacts/views/contacts/listIndex.php
@@ -128,8 +128,8 @@ $this->widget('X2GridViewGeneric', array(
 			'headerHtmlOptions'=>array('class'=>'contact-count'),
 			'htmlOptions'=>array('class'=>'contact-count'),
             'filter' => '',
-			//'value'=>'Yii::app()->locale->numberFormatter->formatDecimal($data["count"])',
-			'value'=>'Yii::app()->locale->numberFormatter->formatDecimal($data->calculateCount ())',
+            // Show estimated count for dynamic lists to avoid multiple expensive calculations
+			'value'=>'Yii::app()->locale->numberFormatter->formatDecimal(($data["type"] == "dynamic") ? $data["count"] : $data->calculateCount ())',
 		),
         array (
             'id' => 'C_gvControls',


### PR DESCRIPTION
* Updated count column of list grid to use estimated count for dynamic
  lists to avoid the possibility of multiple heavy joins.
* Added deliverableItemsCount() method to retrieve only count of
  deliverable items and reduce overhead.
* Updated recordEmailSent() to directly insert Actions into db and
  trigger RecordUpdateTrigger to avoid ActiveRecord overhead.