### PR TITLE
Raymond add to newsletter action

### DIFF
--- a/x2engine/protected/components/x2flow/actions/X2FlowRecordNewsletterAdd.php
+++ b/x2engine/protected/components/x2flow/actions/X2FlowRecordNewsletterAdd.php
@@ -1,0 +1,83 @@
+<?php
+/***********************************************************************************
+ * X2CRM is a customer relationship management program developed by
+ * X2Engine, Inc. Copyright (C) 2011-2016 X2Engine Inc.
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY X2ENGINE, X2ENGINE DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ * 
+ * You can contact X2Engine, Inc. P.O. Box 66752, Scotts Valley,
+ * California 95067, USA. on our website at www.x2crm.com, or at our
+ * email address: contact@x2engine.com.
+ * 
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ * 
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * X2Engine" logo. If the display of the logo is not reasonably feasible for
+ * technical reasons, the Appropriate Legal Notices must display the words
+ * "Powered by X2Engine".
+ **********************************************************************************/
+
+/**
+ * X2FlowAction that adds a comment to a record
+ *
+ * @package application.components.x2flow.actions
+ */
+class X2FlowRecordNewsletterAdd extends X2FlowAction {
+	public $title = 'Add to Newsletter';
+	public $info = 'Add this record to a newsletter list.';
+
+	public function paramRules() {
+		return array_merge (parent::paramRules (), array (
+			'title' => Yii::t('studio',$this->title),
+			'info' => Yii::t('studio',$this->info),
+			'modelRequired' => 'Contacts',
+			'options' => array(
+				array(
+                    'name'=>'listId',
+                    'label'=>Yii::t('studio', 'List'),
+                    'type'=>'link',
+                    'linkType'=>'X2List',
+                    'linkSource'=>Yii::app()->controller->createUrl(
+					    CActiveRecord::model('X2List')->autoCompleteSource, array (
+                            'weblist' => 1
+                        )
+                    )
+				)
+            )));
+	}
+
+	public function execute(&$params) {
+        $listIdentifier=$this->parseOption('listId',$params);
+        if(is_numeric($listIdentifier)){
+            $list = CActiveRecord::model('X2List')->findByPk($listIdentifier);
+        }else{
+            $list = CActiveRecord::model('X2List')->findByAttributes(
+                array('name'=>$listIdentifier));
+        }
+
+		if($list !== null && $list->modelName === get_class($params['model'])) {
+			if ($list->addIds($params['model']->id, true)) {
+                return array (true, "");
+            } else AuxLib::debugLog('failed');
+		} 
+        return array (false, "");
+	}
+}

--- a/x2engine/protected/components/x2flow/actions/X2FlowRecordNewsletterAdd.php
+++ b/x2engine/protected/components/x2flow/actions/X2FlowRecordNewsletterAdd.php
@@ -36,35 +36,35 @@
  **********************************************************************************/
 
 /**
- * X2FlowAction that adds a comment to a record
+ * X2FlowAction that adds a contact to a newsletter contact list
  *
  * @package application.components.x2flow.actions
  */
 class X2FlowRecordNewsletterAdd extends X2FlowAction {
-	public $title = 'Add to Newsletter';
-	public $info = 'Add this record to a newsletter list.';
+    public $title = 'Add to Newsletter';
+    public $info = 'Add this record to a newsletter list.';
 
-	public function paramRules() {
-		return array_merge (parent::paramRules (), array (
-			'title' => Yii::t('studio',$this->title),
-			'info' => Yii::t('studio',$this->info),
-			'modelRequired' => 'Contacts',
-			'options' => array(
-				array(
+    public function paramRules() {
+        return array_merge (parent::paramRules (), array (
+            'title' => Yii::t('studio',$this->title),
+            'info' => Yii::t('studio',$this->info),
+            'modelRequired' => 'Contacts',
+            'options' => array(
+                array(
                     'name'=>'listId',
                     'label'=>Yii::t('studio', 'List'),
                     'type'=>'link',
                     'linkType'=>'X2List',
                     'linkSource'=>Yii::app()->controller->createUrl(
-					    CActiveRecord::model('X2List')->autoCompleteSource, array (
+                        CActiveRecord::model('X2List')->autoCompleteSource, array (
                             'weblist' => 1
                         )
                     )
-				)
+                )
             )));
-	}
+    }
 
-	public function execute(&$params) {
+    public function execute(&$params) {
         $listIdentifier=$this->parseOption('listId',$params);
         if(is_numeric($listIdentifier)){
             $list = CActiveRecord::model('X2List')->findByPk($listIdentifier);
@@ -73,11 +73,11 @@ class X2FlowRecordNewsletterAdd extends X2FlowAction {
                 array('name'=>$listIdentifier));
         }
 
-		if($list !== null && $list->modelName === get_class($params['model'])) {
-			if ($list->addIds($params['model']->id, true)) {
+        if($list !== null && $list->modelName === get_class($params['model'])) {
+            if ($list->addIds($params['model']->id, true)) {
                 return array (true, "");
-            } else AuxLib::debugLog('failed');
-		} 
+            }
+        }
         return array (false, "");
-	}
+    }
 }

--- a/x2engine/protected/modules/contacts/controllers/ContactsController.php
+++ b/x2engine/protected/modules/contacts/controllers/ContactsController.php
@@ -344,11 +344,13 @@ class ContactsController extends x2base {
         // Optional search parameter for autocomplete
         $qterm = isset($_GET['term']) ? $_GET['term'] . '%' : '';
         $static = isset($_GET['static']) && $_GET['static'];
+        $weblist = isset($_GET['weblist']) && $_GET['weblist'];
         $result = Yii::app()->db->createCommand()
                 ->select('id,name as value')
                 ->from('x2_lists')
                 ->where(
                         ($static ? 'type="static" AND ' : '') .
+                        ($weblist ? 'type="weblist" AND ' : '').
                         'modelName="Contacts" AND type!="campaign" 
                     AND name LIKE :qterm' . $condition, array(':qterm' => $qterm))
                 ->order('name ASC')

--- a/x2engine/protected/modules/contacts/models/Contacts.php
+++ b/x2engine/protected/modules/contacts/models/Contacts.php
@@ -123,6 +123,13 @@ class Contacts extends X2Model {
         ));
     }
 
+    public function afterDelete() {
+        parent::afterDelete();
+        // Remove associated X2ListItems
+        Yii::app()->db->createCommand()
+            ->delete('x2_list_items', 'contactId = :id', array(':id' => $this->id));
+    }
+
     public function afterFind() {
         parent::afterFind();
         if ($this->trackingKey === null && self::$autoPopulateFields) {

--- a/x2engine/protected/tests/fixtures/x2_lists.php
+++ b/x2engine/protected/tests/fixtures/x2_lists.php
@@ -11,7 +11,7 @@ return array(
 		'logicType' => 'AND',
 		'modelName' => 'Contacts',
 		'visibility' => '1',
-		'count' => '1',
+		'count' => '2',
 		'createDate' => '1371871507',
 		'lastUpdated' => '1372728516',
 	),

--- a/x2engine/protected/tests/unit/modules/contacts/models/X2ListTest.php
+++ b/x2engine/protected/tests/unit/modules/contacts/models/X2ListTest.php
@@ -122,7 +122,24 @@ class X2ListTest extends X2DbTestCase {
                 , array_map($emailsInList, $staticClone->listItems));
     }
     
+    public function testAddIds() {
+        $contact = $this->contacts('listTest3');
+        $staticList = $this->lists('testUser');
+        $newsletter = $this->lists('testNewsletter');
+        $prevStaticCount = $staticList->count;
+        $prevNewsletterCount = $newsletter->count;
 
+        $this->assertTrue($staticList->addIds($contact->id));
+        $this->assertEquals($staticList->count, $prevStaticCount + 1);
+
+        // Should fail to add a contact to a newsletter without the $allowNewsletter param
+        $this->assertFalse($newsletter->addIds($contact->id));
+        $this->assertEquals($newsletter->count, $prevNewsletterCount);
+
+        // Should now succeed when adding the contact
+        $this->assertTrue($newsletter->addIds($contact->id, true));
+        $this->assertEquals($newsletter->count, $prevNewsletterCount + 1);
+    }
 }
 
 ?>


### PR DESCRIPTION
In order to provide an easier means of managing a newsletter while
accepting submissions both from newsletter forms and web lead forms, an
AddToNewsletter workflow action has been added. This enables users to
use the New Web Lead trigger to place leads into an existing newsletter
contact list.

Furthermore, an afterDelete() hook has been added to Contacts to remove
old X2ListItem entries, preventing a removed contact from being emailed
and empty X2ListItem entries from lingering in the database.

Includes unit test for X2Lists.addIds() previous and new functionality.